### PR TITLE
HOTFIX: email no email, nav link including en

### DIFF
--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -19,7 +19,7 @@ export default async function LangRootLayout({
         className="container mx-auto flex h-screen max-w-4xl flex-col"
         suppressHydrationWarning={true}
       >
-        <Header />
+        <Header dict={dictionary} />
         <ProfileCard dict={dictionary} />
         <NavBar dict={dictionary} />
         {children}

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -1,10 +1,18 @@
 import Image from 'next/image'
 import Link from 'next/link'
 
-export function Header() {
+export function Header({
+  dict: {
+    metadata: { locale },
+  },
+}: {
+  dict: typeof import('@/dictionaries/en.json')
+}) {
+  const lang = locale === 'en-US' ? '/' : `/${locale.split('-')[0]}`
+
   return (
     <header className="flex justify-between p-6">
-      <Link href="/">
+      <Link href={`${lang}`}>
         <Image
           src="/me-logo.svg"
           alt="devjiwonchoi Logo"

--- a/src/components/layouts/NavBar.tsx
+++ b/src/components/layouts/NavBar.tsx
@@ -1,13 +1,14 @@
 import Link from 'next/link'
 
 export function NavBar({
-  dict: { nav, metadata },
+  dict: {
+    nav,
+    metadata: { locale },
+  },
 }: {
   dict: typeof import('@/dictionaries/en.json')
 }) {
-  // const lang = metadata.locale.split('-')[0]
-  const lang =
-    metadata.locale === 'en-US' ? '/' : `/${metadata.locale.split('-')[0]}/`
+  const lang = locale === 'en-US' ? '/' : `/${locale.split('-')[0]}/`
 
   return (
     <nav className="p-6">

--- a/src/components/layouts/NavBar.tsx
+++ b/src/components/layouts/NavBar.tsx
@@ -5,15 +5,18 @@ export function NavBar({
 }: {
   dict: typeof import('@/dictionaries/en.json')
 }) {
-  const lang = metadata.locale.split('-')[0]
+  // const lang = metadata.locale.split('-')[0]
+  const lang =
+    metadata.locale === 'en-US' ? '/' : `/${metadata.locale.split('-')[0]}/`
+
   return (
     <nav className="p-6">
       <ul className="flex justify-center space-x-4">
         {[
-          [nav.bio, `/${lang}`],
-          [nav.blog, `/${lang}/blog`],
-          // nav.proj, `/${lang}/projects`],
-          [nav.req, `/${lang}/request`],
+          [nav.bio, `${lang}`],
+          [nav.blog, `${lang}blog`],
+          // nav.proj, `${lang}projects`],
+          [nav.req, `${lang}request`],
         ].map(([title, url]) => (
           <li key={title}>
             <Link

--- a/src/utils/actions.ts
+++ b/src/utils/actions.ts
@@ -20,7 +20,7 @@ export async function sendEmailToMe(
     from: email,
     to: 'devjiwonchoi@gmail.com',
     subject: subject,
-    text: 'Sent from jiwonchoi.dev:\n\n' + message,
+    text: `Sent from jiwonchoi.dev:\nemail:${email}\n\n` + message,
   }
 
   try {


### PR DESCRIPTION
This PR fixed the following:

1. i18n link on header logo
2. for en, the nav bar had `/en` not `/`
3. added sender email to the message since the email is sent from me