### PR TITLE
fix: do not import terminal on mobile screen size

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 'use client'
+import useMediaQuery from '@/hooks/use-media-query'
 import dynamic from 'next/dynamic'
 
 const Terminal = dynamic(
@@ -9,9 +10,7 @@ const Terminal = dynamic(
 )
 
 export default function Landing() {
-  return (
-    <main className="mb-auto p-6">
-      <Terminal />
-    </main>
-  )
+  // import terminal conditionally based on screen size
+  const isMd = useMediaQuery('(min-width: 768px)')
+  return <main className="mb-auto p-6">{isMd && <Terminal />}</main>
 }

--- a/src/hooks/use-media-query.ts
+++ b/src/hooks/use-media-query.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Custom hook that tells you whether a given media query is active.
+ *
+ * Inspired by https://usehooks.com/useMedia/
+ * https://gist.github.com/gragland/ed8cac563f5df71d78f4a1fefa8c5633
+ *
+ * ref: https://dev.to/justincy/4-patterns-for-responsive-props-in-react-39ak#responsive-props
+ */
+// TODO: replace with applicable better approach
+export default function useMediaQuery(query: string) {
+  const [matches, setMatches] = useState(false)
+  useEffect(
+    () => {
+      const mediaQuery = window.matchMedia(query)
+      setMatches(mediaQuery.matches)
+      const handler = (event: {
+        matches: boolean | ((prevState: boolean) => boolean)
+      }) => setMatches(event.matches)
+      mediaQuery.addEventListener('change', handler)
+      return () => mediaQuery.removeEventListener('change', handler)
+    },
+    [], // Empty array ensures effect is only run on mount and unmount
+  )
+  return matches
+}

--- a/test/e2e/terminal/views/media-query.spec.ts
+++ b/test/e2e/terminal/views/media-query.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('terminal - media query', () => {
+  test('should render terminal on screen size over 768px', async ({ page }) => {
+    await page.setViewportSize({ width: 769, height: 800 })
+    await page.goto('/')
+
+    await page.waitForSelector('.xterm')
+    expect(await page.isVisible('.xterm')).toBeTruthy()
+  })
+
+  test('should not render terminal on screen size under 768px', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 767, height: 800 })
+    await page.goto('/')
+
+    // wait 1 second for possible terminal rendering
+    await page.waitForTimeout(1000)
+    expect(await page.isVisible('.xterm')).toBeFalsy()
+  })
+})


### PR DESCRIPTION
Importing a terminal on mobile screen size is a waste.
PageSpeed emits a score of 94 on mobile, not a good sign.