### PR TITLE
refactor: add vercel speed and analytics only when hosted on Vercel

### DIFF
--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -7,10 +7,10 @@ module.exports = {
     },
     assert: {
       assertions: {
-        'categories:performance': ['warn', { minScore: 0.95 }],
-        'categories:accessibility': ['error', { minScore: 0.95 }],
-        'categories:best-practices': ['error', { minScore: 0.95 }],
-        'categories:seo': ['error', { minScore: 0.95 }],
+        'categories:performance': ['error', { minScore: 0.97 }],
+        'categories:accessibility': ['error', { minScore: 0.97 }],
+        'categories:best-practices': ['error', { minScore: 0.97 }],
+        'categories:seo': ['error', { minScore: 0.97 }],
       },
     },
     upload: {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -51,7 +51,11 @@ export default function RootLayout({
 }: {
   children: React.ReactNode
 }) {
-  const isHTTPS = headers().get('x-forwarded-proto') === 'https'
+  // Only add these when hosted on Vercel-
+  // since SpeedInsights throw 404 looking for _vercel/scripts,
+  // it affects lighthouse CI scores
+  // See https://vercel.com/docs/edge-network/headers#x-vercel-signature
+  const isVercelHosted = headers().has('x-vercel-signature')
   return (
     <html className={`${GeistMono.className} bg-neutral-950`} lang="en">
       <body className="container mx-auto flex h-screen max-w-4xl flex-col">
@@ -59,7 +63,7 @@ export default function RootLayout({
         <NavBar />
         {children}
         <Footer />
-        {isHTTPS && (
+        {isVercelHosted && (
           <>
             <Analytics />
             <SpeedInsights />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import { headers } from 'next/headers'
 import { Analytics } from '@vercel/analytics/react'
 import { SpeedInsights } from '@vercel/speed-insights/next'
 import { GeistMono } from 'geist/font/mono'
@@ -50,6 +51,7 @@ export default function RootLayout({
 }: {
   children: React.ReactNode
 }) {
+  const isHTTPS = headers().get('x-forwarded-proto') === 'https'
   return (
     <html className={`${GeistMono.className} bg-neutral-950`} lang="en">
       <body className="container mx-auto flex h-screen max-w-4xl flex-col">
@@ -57,8 +59,12 @@ export default function RootLayout({
         <NavBar />
         {children}
         <Footer />
-        <Analytics />
-        <SpeedInsights />
+        {isHTTPS && (
+          <>
+            <Analytics />
+            <SpeedInsights />
+          </>
+        )}
       </body>
     </html>
   )


### PR DESCRIPTION
Since Speed Insights throw 404 on looking for `_vercel/scripts`, it affects lighthouse CI.