### PR TITLE
fix: turbo.json cache env

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,7 @@
     "build": {
       "dependsOn": ["^build"],
       "outputs": [".next/**", "!.next/cache/**"],
-      "env": ["CRON_SECRET", "GITHUB_ACCESS_TOKEN", "RESEND_API_KEY"]
+      "env": ["CRON_SECRET", "GITHUB_ACCESS_TOKEN", "RESEND_API_KEY", "VERCEL_ENV"]
     }
   },
   "ui": "tui"


### PR DESCRIPTION
This will make sure you don't share cache between preview and production which can be dangerous.

https://vercel.com/docs/projects/environment-variables/system-environment-variables#VERCEL_ENV